### PR TITLE
Custom processor

### DIFF
--- a/src/Database/DB2Connection.php
+++ b/src/Database/DB2Connection.php
@@ -130,20 +130,19 @@ class DB2Connection extends Connection
         return $defaultGrammar;
     }
 
-    /**
+   /**
      * Get the default post processor instance.
      *
-     * @return \Cooperl\DB2\Database\Query\Processors\DB2Processor|\Cooperl\DB2\Database\Query\Processors\DB2ZOSProcessor
+     * @return \Cooperl\Database\DB2\Query\Processors\DB2Processor|\Cooperl\Database\DB2\Query\Processors\DB2ZOSProcessor
      */
     protected function getDefaultPostProcessor()
     {
-        switch ($this->config['driver']) {
-            case 'db2_zos_odbc':
-                $defaultProcessor = new DB2ZOSProcessor;
-                break;
-            default:
-                $defaultProcessor = new DB2Processor;
-                break;
+        if (!empty(($this->config['processor']))) {
+            $defaultProcessor = new $this->config['processor'];
+        } elseif ($this->config['driver'] === 'db2_zos_odbc') {
+            $defaultProcessor = new DB2ZOSProcessor;
+        } else {
+            $defaultProcessor = new DB2Processor;
         }
 
         return $defaultProcessor;

--- a/src/Database/DB2Connection.php
+++ b/src/Database/DB2Connection.php
@@ -130,10 +130,10 @@ class DB2Connection extends Connection
         return $defaultGrammar;
     }
 
-   /**
+    /**
      * Get the default post processor instance.
      *
-     * @return \Cooperl\Database\DB2\Query\Processors\DB2Processor|\Cooperl\Database\DB2\Query\Processors\DB2ZOSProcessor
+     * @return \Cooperl\DB2\Database\Query\Processors\DB2Processor|\Cooperl\DB2\Database\Query\Processors\DB2ZOSProcessor
      */
     protected function getDefaultPostProcessor()
     {

--- a/src/config/db2.php
+++ b/src/config/db2.php
@@ -88,6 +88,9 @@ return [
             'schema' => 'default schema',
             'port' => 50000,
             'date_format' => 'Y-m-d H:i:s',
+            // Can be used to overwrite the default result processor. E.g. My\Custom\DB2Processor::class
+            // If you leave this empty the default processor wil be used. 
+            'processor' => null,
             'odbc_keywords' => [
                 'SIGNON' => 3,
                 'SSL' => 0,


### PR DESCRIPTION
This modification enables the possibility to configure a custom DB2 processor.

The Processor class can contain the processSelect() method. This method enables you to modify the results returned by the database before it is handed over to Laravel. We use this for the following
* Trim values returned by the database.
* Convert values from ISO-8859-1 to UTF8.
* The column names we use are cryptic, e.g. TBEUSRI. We rename these cryptic column names to something readable like userId.
* Resolving issues related to https://github.com/cooperl22/laravel-db2/issues?q=++AGGREGATE+ . By casting AGGREGATE to the lowercase aggregate as expected by laravel.